### PR TITLE
Feature/#5 post

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'

--- a/src/main/java/com/community/dev/domain/post/Post.java
+++ b/src/main/java/com/community/dev/domain/post/Post.java
@@ -6,11 +6,13 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Entity
 public class Post {
 
+    @Setter
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/com/community/dev/domain/post/Post.java
+++ b/src/main/java/com/community/dev/domain/post/Post.java
@@ -1,0 +1,33 @@
+package com.community.dev.domain.post;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Post {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String contents;
+
+    protected Post() {}
+
+    @Builder
+    public Post(String title, String contents) {
+        this.title = title;
+        this.contents = contents;
+    }
+
+    public void updatePost(String title, String contents) {
+        this.title = title;
+        this.contents = contents;
+    }
+}

--- a/src/main/java/com/community/dev/domain/post/PostRepo.java
+++ b/src/main/java/com/community/dev/domain/post/PostRepo.java
@@ -1,0 +1,6 @@
+package com.community.dev.domain.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepo extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/community/dev/service/post/PostService.java
+++ b/src/main/java/com/community/dev/service/post/PostService.java
@@ -1,0 +1,53 @@
+package com.community.dev.service.post;
+
+import com.community.dev.domain.post.Post;
+import com.community.dev.domain.post.PostRepo;
+import com.community.dev.web.dto.PostRequestDto;
+import com.community.dev.web.dto.PostResponseDto;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.EntityNotFoundException;
+import javax.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostService {
+
+    private final PostRepo postRepo;
+
+    public PostService(PostRepo postRepo) {
+        this.postRepo = postRepo;
+    }
+
+    public void createPost(PostRequestDto requestDto) {
+        postRepo.save(requestDto.toEntity());
+    }
+
+    @Transactional
+    public void deletePost(Long id) {
+        isExist(id);
+        postRepo.deleteById(id);
+    }
+
+    public List<PostResponseDto> getPost(Long id) {
+        isExist(id);
+        return postRepo.findById(id).stream().map(PostResponseDto::from)
+            .collect(Collectors.toList());
+    }
+
+    public List<PostResponseDto> getAllPosts() {
+        List<Post> posts = postRepo.findAll();
+        return posts.stream().map(PostResponseDto::from).collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void updatePost(PostRequestDto requestDto, Long postId) {
+        Post post = isExist(postId);
+        post.updatePost(requestDto.getTitle(), requestDto.getContents());
+    }
+
+    public Post isExist(Long id) {
+        return postRepo.findById(id).orElseThrow(() ->
+            new EntityNotFoundException("게시글이 없습니다."));
+    }
+}

--- a/src/main/java/com/community/dev/service/post/PostService.java
+++ b/src/main/java/com/community/dev/service/post/PostService.java
@@ -29,10 +29,8 @@ public class PostService {
         postRepo.deleteById(id);
     }
 
-    public List<PostResponseDto> getPost(Long id) {
-        isExist(id);
-        return postRepo.findById(id).stream().map(PostResponseDto::from)
-            .collect(Collectors.toList());
+    public PostResponseDto getPost(Long postId) {
+        return PostResponseDto.from(isExist(postId));
     }
 
     public List<PostResponseDto> getAllPosts() {

--- a/src/main/java/com/community/dev/web/PostApiController.java
+++ b/src/main/java/com/community/dev/web/PostApiController.java
@@ -34,7 +34,7 @@ public class PostApiController {
     }
 
     @GetMapping("/{postId}")
-    public List<PostResponseDto> getPost(@PathVariable Long postId) {
+    public PostResponseDto getPost(@PathVariable Long postId) {
         return postService.getPost(postId);
     }
 

--- a/src/main/java/com/community/dev/web/PostApiController.java
+++ b/src/main/java/com/community/dev/web/PostApiController.java
@@ -1,0 +1,50 @@
+package com.community.dev.web;
+
+import com.community.dev.service.post.PostService;
+import com.community.dev.web.dto.PostRequestDto;
+import com.community.dev.web.dto.PostResponseDto;
+import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/posts")
+@RestController
+public class PostApiController {
+
+    private final PostService postService;
+
+    public PostApiController(PostService postService) {
+        this.postService = postService;
+    }
+
+    @PostMapping
+    public void createPost(@RequestBody PostRequestDto requestDto) {
+        postService.createPost(requestDto);
+    }
+
+    @DeleteMapping("/{postId}")
+    public void deletePost(@PathVariable Long postId) {
+        postService.deletePost(postId);
+    }
+
+    @GetMapping("/{postId}")
+    public List<PostResponseDto> getPost(@PathVariable Long postId) {
+        return postService.getPost(postId);
+    }
+
+    @GetMapping
+    public List<PostResponseDto> getAllPosts() {
+        return postService.getAllPosts();
+    }
+
+    @PutMapping("/{postId}")
+    public void updatePost(@PathVariable Long postId, @RequestBody PostRequestDto requestDto) {
+        postService.updatePost(requestDto, postId);
+    }
+}

--- a/src/main/java/com/community/dev/web/PostController.java
+++ b/src/main/java/com/community/dev/web/PostController.java
@@ -1,0 +1,76 @@
+package com.community.dev.web;
+
+import com.community.dev.domain.post.Post;
+import com.community.dev.domain.post.PostRepo;
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/posts/")
+public class PostController {
+
+    private final PostRepo postRepo;
+
+    @Autowired
+    public PostController(PostRepo postRepo) {
+        this.postRepo = postRepo;
+    }
+
+    @GetMapping("write")
+    public String showSignUpForm(Post post) {
+        return "post-add";
+    }
+
+    @GetMapping("list")
+    public String showUpdateForm(Model model) {
+        model.addAttribute("posts", postRepo.findAll());
+        return "post-index";
+    }
+
+    @PostMapping("write")
+    public String writePost(@Valid Post post, BindingResult result, Model model) {
+        if (result.hasErrors()) {
+            return "post-add";
+        }
+
+        postRepo.save(post);
+        return "redirect:list";
+    }
+
+    @GetMapping("edit/{id}")
+    public String showUpdateForm(@PathVariable("id") long id, Model model) {
+        Post post = postRepo.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("Invalid post Id:" + id));
+        model.addAttribute("post", post);
+        return "post-update";
+    }
+
+    @PostMapping("update/{id}")
+    public String updatePost(@PathVariable("id") long id, @Valid Post post, BindingResult result,
+        Model model) {
+        if (result.hasErrors()) {
+            post.setId(id);
+            return "post-update";
+        }
+
+        postRepo.save(post);
+        model.addAttribute("posts", postRepo.findAll());
+        return "post-index";
+    }
+
+    @GetMapping("delete/{id}")
+    public String deletePost(@PathVariable("id") long id, Model model) {
+        Post post = postRepo.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("Invalid post Id:" + id));
+        postRepo.delete(post);
+        model.addAttribute("posts", postRepo.findAll());
+        return "post-index";
+    }
+}

--- a/src/main/java/com/community/dev/web/dto/PostRequestDto.java
+++ b/src/main/java/com/community/dev/web/dto/PostRequestDto.java
@@ -1,0 +1,28 @@
+package com.community.dev.web.dto;
+
+
+import com.community.dev.domain.post.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PostRequestDto {
+    private String title;
+    private String contents;
+
+    public PostRequestDto() {}
+
+    @Builder
+    public PostRequestDto(String title, String contents) {
+        this.title = title;
+        this.contents = contents;
+    }
+
+
+    public Post toEntity() {
+        return Post.builder()
+            .title(title)
+            .contents(contents)
+            .build();
+    }
+}

--- a/src/main/java/com/community/dev/web/dto/PostResponseDto.java
+++ b/src/main/java/com/community/dev/web/dto/PostResponseDto.java
@@ -1,0 +1,25 @@
+package com.community.dev.web.dto;
+
+
+import com.community.dev.domain.post.Post;
+import lombok.Getter;
+
+@Getter
+public class PostResponseDto {
+
+    private Long id;
+    private String title;
+    private String contents;
+
+    protected PostResponseDto() {}
+
+    private PostResponseDto(Long id, String title, String contents) {
+        this.id = id;
+        this.title = title;
+        this.contents = contents;
+    }
+
+    public static PostResponseDto from(Post entity) {
+        return new PostResponseDto(entity.getId(), entity.getTitle(), entity.getContents());
+    }
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -12,78 +12,8 @@
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 </head>
 <body>
-<nav class="navbar is-white topNav">
-  <div class="container">
-    <div class="navbar-brand">
-      <a class="navbar-item" href="/">
-        <img src="/image/logo.png" width="112" height="28">
-      </a>
-      <div class="navbar-burger burger" data-target="topNav">
-        <span></span>
-        <span></span>
-        <span></span>
-      </div>
-    </div>
-    <div id="topNav" class="navbar-menu">
-      <div class="navbar-start">
-        <a class="navbar-item" href="">자유 게시판</a>
-        <a class="navbar-item" href="">질문 게시판</a>
-        <a class="navbar-item" href="">기술 공유</a>
-        <a class="navbar-item" href="">스터디 모임</a>
-        <a class="navbar-item" href="">회고</a>
-        <a class="navbar-item" href="">홍보</a>
-      </div>
-      <div class="navbar-end">
-        <div class="navbar-item">
-          <div class="field is-grouped">
-            <p class="control">
-            </p>
-            Login as: <span th:text="${userName}"></span>
-            <button class="button is-primary update-modal" sec:authorize="!isAuthenticated()">로그인</button>
-            <button class="button is-primary">
-               <a th:href="@{/}" role="button">Logout</a>
-            </button>
-          </div>
+<div th:replace="/nav :: nav"></div>
 
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div id="update-modal" class="modal">
-    <div class="modal-background"></div>
-    <div class="modal-card">
-      <header class="modal-card-head">
-        <p class="modal-card-title">Social Login</p>
-        <button class="delete update-modal-close" aria-label="close"></button>
-      </header>
-      <section class="modal-card-body">
-        <div class="field is-grouped">
-          <p class="control">
-            <a class="button is-small is-info is-outlined" th:href="@{/oauth2/authorization/google}">
-										<span class="icon">
-											<i class="fa fa-user"></i>
-										</span>
-              <span>google login</span>
-            </a>
-            <a class="button is-small is-info is-outlined" th:href="@{/oauth2/authorization/kakao}">
-										<span class="icon">
-											<i class="fa fa-user"></i>
-										</span>
-              <span>kakao login</span>
-            </a>
-            <a class="button is-small is-info is-outlined" th:href="@{/oauth2/authorization/github}">
-										<span class="icon">
-											<i class="fa fa-user"></i>
-										</span>
-              <span>github login</span>
-            </a>
-          </p>
-        </div>
-      </section>
-    </div>
-  </div>
-</nav>
 <h1>소셜 로그인 테스트</h1>
 <h2 th:text="${provider}"> 앱 </h2>
 <h2 th:text="${oauthId}"> 아이디 </h2>

--- a/src/main/resources/templates/nav.html
+++ b/src/main/resources/templates/nav.html
@@ -1,0 +1,72 @@
+<nav class="navbar is-white topNav">
+  <div class="container">
+    <div class="navbar-brand">
+      <a class="navbar-item" href="/">
+        <img src="/image/logo.png" width="112" height="28">
+      </a>
+      <div class="navbar-burger burger" data-target="topNav">
+        <span></span>
+        <span></span>
+        <span></span>
+      </div>
+    </div>
+    <div id="topNav" class="navbar-menu">
+      <div class="navbar-start">
+        <a class="navbar-item" href="/posts/list">자유 게시판</a>
+        <a class="navbar-item" href="/qna">질문 게시판</a>
+        <a class="navbar-item" href="/tech">기술 공유</a>
+        <a class="navbar-item" href="/gathering">스터디 모임</a>
+        <a class="navbar-item" href="/retrospective">회고</a>
+        <a class="navbar-item" href="/promotion">홍보</a>
+      </div>
+      <div class="navbar-end">
+        <div class="navbar-item">
+          <div class="field is-grouped">
+            <p class="control">
+            </p>
+            Login as: <span th:text="${userName}"></span>
+            <button class="button is-primary update-modal" sec:authorize="!isAuthenticated()">로그인</button>
+            <button class="button is-primary">
+              <a th:href="@{/}" role="button">Logout</a>
+            </button>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="update-modal" class="modal">
+    <div class="modal-background"></div>
+    <div class="modal-card">
+      <header class="modal-card-head">
+        <p class="modal-card-title">Social Login</p>
+        <button class="delete update-modal-close" aria-label="close"></button>
+      </header>
+      <section class="modal-card-body">
+        <div class="field is-grouped">
+          <p class="control">
+            <a class="button is-small is-info is-outlined" th:href="@{/oauth2/authorization/google}">
+										<span class="icon">
+											<i class="fa fa-user"></i>
+										</span>
+              <span>google login</span>
+            </a>
+            <a class="button is-small is-info is-outlined" th:href="@{/oauth2/authorization/kakao}">
+										<span class="icon">
+											<i class="fa fa-user"></i>
+										</span>
+              <span>kakao login</span>
+            </a>
+            <a class="button is-small is-info is-outlined" th:href="@{/oauth2/authorization/github}">
+										<span class="icon">
+											<i class="fa fa-user"></i>
+										</span>
+              <span>github login</span>
+            </a>
+          </p>
+        </div>
+      </section>
+    </div>
+  </div>
+</nav>

--- a/src/main/resources/templates/post-add.html
+++ b/src/main/resources/templates/post-add.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz" crossorigin="anonymous">
+    <title>JuniorDev</title>
+    <link rel="stylesheet"
+          href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
+    <link rel="stylesheet" href="https://unpkg.com/bulma@0.9.0/css/bulma.min.css"/>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+</head>
+<div th:replace="/nav :: nav"></div>
+<body>
+<div class="container is-max-desktop">
+    <div class="notification is-primary">
+        <form action="#" th:action="@{/posts/write}" th:object="${post}" method="post">
+        <div class="field">
+            <label class="label">카테고리</label>
+            <div class="control">
+                <div class="select">
+                    <select>
+                        <option selected>자유게시판</option>
+                        <option>질문게시판</option>
+                        <option>기술 공유</option>
+                        <option>스터디 모임</option>
+                        <option>회고</option>
+                        <option>홍보</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+
+        <div class="field">
+            <label class="label">작성자</label>
+            <div class="control has-icons-left has-icons-right">
+                <input class="input is-success" type="text" placeholder="Text input" value="bulma">
+                <span class="icon is-small is-left">
+      <i class="fas fa-user"></i>
+    </span>
+            </div>
+        </div>
+
+        <div class="field">
+            <label class="label">제목</label>
+            <div class="control">
+                <input class="input" type="text" placeholder="Text input" th:field="*{title}">
+            </div>
+        </div>
+
+
+
+
+        <div class="field">
+            <label class="label">내용</label>
+            <div class="control">
+                <textarea class="textarea" placeholder="Textarea" th:field="*{contents}"></textarea>
+            </div>
+        </div>
+
+
+        <div class="field is-grouped">
+            <div class="control">
+                <input type="submit" class="button"/>
+            </div>
+        </div>
+        </form>
+    </div>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/post-index.html
+++ b/src/main/resources/templates/post-index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz" crossorigin="anonymous">
+
+    <title>JuniorDev</title>
+    <link rel="stylesheet"
+          href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
+    <link rel="stylesheet" href="https://unpkg.com/bulma@0.9.0/css/bulma.min.css"/>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+</head>
+
+<body>
+<div th:replace="/nav :: nav"></div>
+
+<div class="container is-max-desktop">
+    <div class="notification is-primary">
+        <div th:switch="${posts}">
+            <a href="/posts/write"><button class="button">게시글 작성</button></a>
+
+            <h2 th:case="null">게시글이 없습니다.</h2>
+            <div th:case="*">
+                <table class="table">
+                    <thead>
+                    <tr>
+                        <th><abbr title="no">no</abbr></th>
+                        <th><abbr title="user">작성자</abbr></th>
+                        <th><abbr title="title">제목</abbr></th>
+                        <th><abbr title="delete">수정</abbr></th>
+                        <th><abbr title="edit">삭제</abbr></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="post : ${posts}">
+                        <td th:text="${post.id}"></td>
+                        <td th:text="${userName}"></td>
+                        <td th:text="${post.title}"></td>
+                        <td><a th:href="@{/posts/edit/{id}(id=${post.id})}"><i class="fas fa-user-edit ml-2"></i></a></td>
+                        <td><a th:href="@{/posts/delete/{id}(id=${post.id})}"><i class="fas fa-user-times ml-2"></i></a></td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+
+
+        </div>
+
+    </div>
+</div>
+</body>
+<!DOCTYPE html>

--- a/src/main/resources/templates/post-update.html
+++ b/src/main/resources/templates/post-update.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz" crossorigin="anonymous">
+    <title>JuniorDev</title>
+    <link rel="stylesheet"
+          href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
+    <link rel="stylesheet" href="https://unpkg.com/bulma@0.9.0/css/bulma.min.css"/>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+</head>
+<div th:replace="/nav :: nav"></div>
+<body>
+<div class="container is-max-desktop">
+    <div class="notification is-primary">
+        <form action="#" th:action="@{/posts/update/{id}(id=${post.id})}" th:object="${post}" method="post">
+        <div class="field">
+                <label class="label">카테고리</label>
+                <div class="control">
+                    <div class="select">
+                        <select>
+                            <option selected>자유게시판</option>
+                            <option>질문게시판</option>
+                            <option>기술 공유</option>
+                            <option>스터디 모임</option>
+                            <option>회고</option>
+                            <option>홍보</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+
+            <div class="field">
+                <label class="label">작성자</label>
+                <div class="control has-icons-left has-icons-right">
+                    <input class="input is-success" type="text" placeholder="Text input" value="bulma">
+                    <span class="icon is-small is-left">
+      <i class="fas fa-user"></i>
+    </span>
+                </div>
+            </div>
+
+            <div class="field">
+                <label class="label">제목</label>
+                <div class="control">
+                    <input class="input" type="text" placeholder="Text input" th:field="*{title}">
+                </div>
+            </div>
+
+
+
+
+            <div class="field">
+                <label class="label">내용</label>
+                <div class="control">
+                    <textarea class="textarea" placeholder="Textarea" th:field="*{contents}"></textarea>
+                </div>
+            </div>
+
+
+            <div class="field is-grouped">
+                <div class="control">
+                    <input type="submit" class="button"/>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## 작업 목적
게시글을 쓰고, 수정하고, 삭제하고, 전체 목록 확인을 하기 위한 작업을 진행했습니다.

## 주요 변경점
- 게시글 목록 화면 
- 게시글 CRUD 기능 추가

## 참고
- 현재 자유게시판 카테고리를 클릭하면 아래 사진과 같이 /posts/list 로 이동하고 해당 페이지에서 게시글을 작성하고, 수정하고, 삭제할 수 있는 것까지 작업을 했습니다. 
- 추가적으로 로그인 유지를 세션, 쿠키, JWT 토큰의 방식 중 어떻게 하는게 좋을지 고민을 해봤지만 아직 해결하지 못했습니다. 

![image](https://user-images.githubusercontent.com/61692282/192860917-87db0415-2ae4-4307-ab93-cc1609241393.png)
